### PR TITLE
Match muAdvGameOverTask create

### DIFF
--- a/config/RSBE01_02/rels/sora_adv_menu_game_over/splits.txt
+++ b/config/RSBE01_02/rels/sora_adv_menu_game_over/splits.txt
@@ -6,6 +6,9 @@ Sections:
 	.data       type:data align:32
 	.bss        type:bss align:8
 
+mo_adv_menu/sora_adv_menu_game_over/mu_adv_game_over.cpp:
+	.text       start:0x00000000 end:0x00000044
+
 mo_adv_menu/mo_adv_menu.cpp:
 	.text       start:0x000034C8 end:0x00003564
 	.data       start:0x000004D8 end:0x000004E8

--- a/configure.py
+++ b/configure.py
@@ -636,7 +636,9 @@ config.libs = [
         "mw_version": config.linker_version,
         "cflags": cflags_rel,
         "host": False,
-        "objects": [],
+        "objects": [
+            Object(Matching, "mo_adv_menu/sora_adv_menu_game_over/mu_adv_game_over.cpp"),
+        ],
     },
     {
         "lib": "sora_adv_menu_name",

--- a/src/mo_adv_menu/sora_adv_menu_game_over/mu_adv_game_over.cpp
+++ b/src/mo_adv_menu/sora_adv_menu_game_over/mu_adv_game_over.cpp
@@ -1,0 +1,15 @@
+#include <mu/adv/mu_adv_game_over.h>
+#include <sr/sr_common.h>
+#include <types.h>
+
+extern "C" muAdvGameOverTask* fn_33_44(muAdvGameOverTask* task,
+        const muAdvGameOverTaskParam* param);
+
+muAdvGameOverTask* muAdvGameOverTask::create(const muAdvGameOverTaskParam* param) {
+    muAdvGameOverTask* task = static_cast<muAdvGameOverTask*>(
+            operator new(0x3F8, Heaps::MenuInstance));
+    if (task != nullptr) {
+        task = fn_33_44(task, param);
+    }
+    return task;
+}


### PR DESCRIPTION
## Summary
- add a matching source split for `muAdvGameOverTask::create(const muAdvGameOverTaskParam*)`
- wire `sora_adv_menu_game_over` to build the new source object
- split `.text:0x00000000..0x00000044` out of the auto assembly object

## Matching
- `muAdvGameOverTask::create(const muAdvGameOverTaskParam*)`: 100.0%
- unit `sora_adv_menu_game_over/mo_adv_menu/sora_adv_menu_game_over/mu_adv_game_over`: 100.0%

## Verification
- `ninja`
- `127 files OK`
- Progress after build: `All: 1.09% matched, 0.93% linked (493 / 4392 files)`
